### PR TITLE
[APP] File Explorer - Lazy Loading Improvements

### DIFF
--- a/USER/_registry.json
+++ b/USER/_registry.json
@@ -9,7 +9,7 @@
     "name": "File Explorer",
     "tip": "Press play again to stop currently playing media.",
     "type": "APP",
-    "version": "1.1.0"
+    "version": "1.2.0"
   },
   {
     "author": "Cody Tolene",

--- a/docs/loader.js
+++ b/docs/loader.js
@@ -41,7 +41,7 @@ connectBtn.addEventListener('click', async () => {
       });
 
       console.log('Connected to Pip-Boy!');
-      alert('Connected to Pip-Boy!');
+      //alert('Connected to Pip-Boy!');
       updateUIConnectionState();
     } else {
       alert('Connection failed.');
@@ -117,7 +117,6 @@ fileInput.addEventListener('change', async (e) => {
         g.clear(1);
         if (g.setFontMonofonto23) g.setFontMonofonto23();
         g.setFontAlign(0, 0);
-        g.flip();
 
         return "Screen cleared";
       } catch (e) {
@@ -150,7 +149,7 @@ fileInput.addEventListener('change', async (e) => {
     });
 
     if (result?.success) {
-      alert(result.message);
+      // alert(result.message);
       console.log(result.message);
       fileInput.value = '';
     } else {
@@ -180,7 +179,7 @@ restartBtn.addEventListener('click', async () => {
     fileInput.disabled = true;
     restartBtn.disabled = true;
 
-    alert('Reboot command sent!');
+    //alert('Reboot command sent!');
   } catch (err) {
     alert('Error rebooting device: ' + err.message);
     console.error('Reboot error:', err);


### PR DESCRIPTION
### Description

Previously performed a deep, recursive traversal of the entire directory tree up front. Which was memory intensive and sometimes failed.

Now, things are lazy and only load 1 depth at a time. Click into folders now rather than listing out all contents right away like it was previously.

### Update Checklist

- [x] Add app to the `USER` directory.
- [x] App is a `.js` file is PascalCase.
- [x] Add app to the `USER/_registry.json` file.

### Pull Request Checklist (to be filled by the reviewer)

- [x] Tested

### Preview(s)

![image](https://github.com/user-attachments/assets/ce4789cb-e82c-4f86-97a7-4e348e597e50)

