### PR TITLE
[APP][BUG] Stats Display v2.0.1 - Bugfix for the stats app when no perks have been enabled previously

### DIFF
--- a/USER/StatsDisplay.js
+++ b/USER/StatsDisplay.js
@@ -59,7 +59,13 @@ function draw() {
 }
 
 function buildScreen(directory) {
-  let files = require('fs').readdirSync(directory);
+  var files;
+  try {
+    files = require('fs').readdirSync(directory);
+  } catch {
+    require('fs').mkdir(directory);
+    files = require('fs').readdirSync(directory);
+  }
   loadedListMax = files.length;
   if (files.length == 0) {
     drawEmptyScreen();
@@ -132,9 +138,12 @@ function buildPerkSelectionScreen() {
 
 function generatePerksConfigLists() {
   //first load of screen, build the full list.
-  let files = require('fs').readdirSync(enabledPerkFolder);
-  if (files == undefined) {
+  var files;
+  try {
+    files = require('fs').readdirSync(enabledPerkFolder);
+  } catch {
     require('fs').mkdir(enabledPerkFolder);
+    files = require('fs').readdirSync(enabledPerkFolder);
   }
   for (file of files) {
     enabledPerks.push(file);

--- a/USER/_registry.json
+++ b/USER/_registry.json
@@ -92,7 +92,7 @@
     "name": "Stats Display",
     "tip": "",
     "type": "APP",
-    "version": "2.0.0"
+    "version": "2.0.1"
   },
   {
     "author": "Cody Tolene",


### PR DESCRIPTION
### Description

Small bugfix for when no perks have been previously enabled (i.e. for new users)

### Update Checklist

- [x] Add app to the `USER` directory.
- [x] App is a `.js` file is PascalCase.
- [x] Add app to the `USER/_registry.json` file.

### Pull Request Checklist (to be filled by the reviewer)

- [x] Tested

### Preview(s)

- Add any preview animations, videos, or screenshots of the app here.
